### PR TITLE
feat: implement cli feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,3 +169,44 @@ This project is licensed under the [GNU Affero General Public License v3.0 (AGPL
 ---
 
 *Built for the macOS developer community.*
+
+### Open a repository from Terminal
+
+On launch, Commit+ shows a setup tip if the CLI and shell PATH are not configured.
+Click **Install CLI & Configure PATH** to complete both steps. **Close** reminds you
+on the next launch if setup is unfinished; **Don't remind** disables the startup tip.
+Once setup is complete, the tip is skipped. You can also install from
+**Settings → General → Command Line**.
+
+Installation creates `~/.local/bin/commit` pointing to the helper inside this app. Keep
+Commit+ in a stable location (for example `/Applications`) before installing.
+Existing files and commands are never overwritten.
+
+The install button also adds `export PATH="$HOME/.local/bin:$PATH"` to your shell
+configuration (zsh or bash; fish uses its equivalent). Existing files are backed up
+beside the originals before appending, and repeated installation does not duplicate
+the line. Open a new terminal afterward, or run the displayed PATH command in your
+current terminal. Run `command -v commit` to check for another command, alias, or
+function with that name.
+
+```sh
+commit                  # Open the current folder's repository
+commit .                # Same behavior
+commit "/path/to/repo"   # Open a specific repository
+commit --help
+```
+
+Subfolders resolve to the working-tree root; linked worktrees and repositories
+without commits are supported. Bare repositories are not supported. This command
+opens a repository; it does not create a Git commit. It uses the app's Git runtime
+preference, including downloaded Embedded Git. If no suitable Git runtime exists,
+the command reports an error and does not download or launch anything.
+
+Invalid folders produce stderr and a nonzero exit code without opening Commit+.
+Exit code 0 means macOS accepted the open request; errors after handoff are shown
+in the app. Existing repository windows are focused when available.
+
+To uninstall, remove the symlink `~/.local/bin/commit`. If you move the app, remove
+that symlink and install the command again from the app's new location.
+
+CLI checks run without launching the app: `bash scripts/test-command-line.sh`.

--- a/command-line/CommitCommand.swift
+++ b/command-line/CommitCommand.swift
@@ -1,0 +1,67 @@
+//
+//  macgit (Commit+) - a macOS Git client built with Swift and SwiftUI.
+//  Copyright (C) 2026  Thanh Tran <trantienthanh2412@gmail.com>
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Affero General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Affero General Public License for more details.
+//
+//  You should have received a copy of the GNU Affero General Public License
+//  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import AppKit
+import Foundation
+import MachO
+
+@main
+struct CommitCommand {
+    @MainActor static func main() async {
+        let arguments = Array(CommandLine.arguments.dropFirst())
+        if arguments == ["--help"] || arguments == ["-h"] {
+            print("Usage: commit [<folder>]\nOpen the current folder's Git repository in Commit+. This does not create a commit.")
+            return
+        }
+        do {
+            let directory = try RepositoryOpenRequest.directory(
+                arguments: arguments, currentDirectory: FileManager.default.currentDirectoryPath
+            )
+            // Resolve the installed symlink to target this helper's app, including when several builds exist.
+            var capacity: UInt32 = 0
+            _NSGetExecutablePath(nil, &capacity)
+            var buffer = [CChar](repeating: 0, count: Int(capacity))
+            guard _NSGetExecutablePath(&buffer, &capacity) == 0 else {
+                throw RepositoryOpenError.message("Cannot locate the installed command.")
+            }
+            let executable = URL(fileURLWithPath: String(cString: buffer)).resolvingSymlinksInPath()
+            let application = executable.deletingLastPathComponent().deletingLastPathComponent().deletingLastPathComponent()
+            guard application.pathExtension == "app", let bundle = Bundle(url: application),
+                  let identifier = bundle.bundleIdentifier else {
+                throw RepositoryOpenError.message("Cannot locate Commit+. Reinstall the command from Settings > General.")
+            }
+            let live = GitRuntimeConfiguration.live()
+            let configuration = GitRuntimeConfiguration(
+                applicationSupportDirectory: live.applicationSupportDirectory,
+                candidateSystemGitURLs: live.candidateSystemGitURLs,
+                manifest: live.manifest,
+                preferenceDefaults: UserDefaults(suiteName: identifier) ?? .standard,
+                preferenceKey: live.preferenceKey
+            )
+            let root = try await RepositoryPathResolver().root(at: directory, runtime: GitRuntimeManager(configuration: configuration))
+            let options = NSWorkspace.OpenConfiguration()
+            options.activates = true
+            _ = try await NSWorkspace.shared.open(
+                [RepositoryOpenRequest.url(for: root)], withApplicationAt: application, configuration: options
+            )
+        } catch {
+            FileHandle.standardError.write(Data("commit: \(error.localizedDescription)\n".utf8))
+            exit(1)
+        }
+    }
+}

--- a/command-line/Tests.swift
+++ b/command-line/Tests.swift
@@ -1,0 +1,168 @@
+//
+//  macgit (Commit+) - a macOS Git client built with Swift and SwiftUI.
+//  Copyright (C) 2026  Thanh Tran <trantienthanh2412@gmail.com>
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Affero General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Affero General Public License for more details.
+//
+//  You should have received a copy of the GNU Affero General Public License
+//  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Foundation
+
+@main
+struct CommandLineTests {
+    @MainActor static func main() async throws {
+        var checks = 0
+        func check(_ condition: Bool, _ label: String) {
+            precondition(condition, label)
+            checks += 1
+        }
+        func rejects(_ body: () throws -> Void) {
+            do { try body(); preconditionFailure("Expected rejection") } catch { checks += 1 }
+        }
+        let manager = FileManager.default
+        let temporary = manager.temporaryDirectory.appendingPathComponent("commit-cli-tests-\(UUID().uuidString)")
+        try manager.createDirectory(at: temporary, withIntermediateDirectories: true)
+        defer { try? manager.removeItem(at: temporary) }
+        let unusual = temporary.appendingPathComponent("repo tiếng Việt #&?% + \n")
+        try manager.createDirectory(at: unusual, withIntermediateDirectories: true)
+        let url = RepositoryOpenRequest.url(for: unusual)
+        check(try RepositoryOpenRequest.repositoryURL(from: url).path == unusual.path, "URL round trip")
+        check(try RepositoryOpenRequest.directory(arguments: [], currentDirectory: unusual.path).path == unusual.path, "No args")
+        check(try RepositoryOpenRequest.directory(arguments: ["."], currentDirectory: unusual.path).path == unusual.path, "Dot")
+        check(try RepositoryOpenRequest.directory(arguments: ["--", "-repo"], currentDirectory: temporary.path).lastPathComponent == "-repo", "Literal dash")
+        rejects { _ = try RepositoryOpenRequest.directory(arguments: ["a", "b"], currentDirectory: temporary.path) }
+        rejects { _ = try RepositoryOpenRequest.directory(arguments: ["--unknown"], currentDirectory: temporary.path) }
+        for raw in ["macgit://open-repository?path=relative", "macgit://open-repository?path=/a&path=/b", "macgit://open-repository?path=/a&extra=x", "macgit://open-repository?path=%00", "macgit://open-repository/other?path=/a", "macgit://session?path=/a"] {
+            rejects { _ = try RepositoryOpenRequest.repositoryURL(from: URL(string: raw)!) }
+        }
+        func git(_ arguments: [String]) throws {
+            let process = Process()
+            process.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+            process.arguments = arguments
+            process.standardOutput = FileHandle.nullDevice
+            process.standardError = FileHandle.nullDevice
+            try process.run()
+            process.waitUntilExit()
+            precondition(process.terminationStatus == 0, "Git fixture failed")
+        }
+        try git(["init", unusual.path])
+        let defaultsName = "commit-cli-tests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: defaultsName)!
+        defer { defaults.removePersistentDomain(forName: defaultsName) }
+        let runtime = GitRuntimeManager(configuration: GitRuntimeConfiguration(
+            applicationSupportDirectory: temporary,
+            candidateSystemGitURLs: [URL(fileURLWithPath: "/usr/bin/git")],
+            manifest: .current, preferenceDefaults: defaults, preferenceKey: "runtime"
+        ))
+        let resolver = RepositoryPathResolver()
+        let root = try await resolver.root(at: unusual, runtime: runtime)
+        check(root.path == unusual.resolvingSymlinksInPath().path, "Unborn repo with literal newline")
+        let child = unusual.appendingPathComponent("a/b")
+        try manager.createDirectory(at: child, withIntermediateDirectories: true)
+        check(try await resolver.root(at: child, runtime: runtime) == root, "Subdirectory root")
+        setenv("GIT_DIR", "/nonexistent/override", 1)
+        setenv("GIT_WORK_TREE", "/nonexistent/worktree", 1)
+        check(try await resolver.root(at: child, runtime: runtime) == root, "Ignore inherited Git overrides")
+        unsetenv("GIT_DIR")
+        unsetenv("GIT_WORK_TREE")
+        let link = temporary.appendingPathComponent("linked")
+        try manager.createSymbolicLink(at: link, withDestinationURL: child)
+        check(try await resolver.root(at: link, runtime: runtime) == root, "Symlink root")
+        try git(["-C", unusual.path, "-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "--allow-empty", "-m", "fixture"])
+        let worktree = temporary.appendingPathComponent("worktree")
+        try git(["-C", unusual.path, "worktree", "add", "-b", "fixture", worktree.path])
+        check(try await resolver.root(at: worktree, runtime: runtime).path == worktree.resolvingSymlinksInPath().path, "Linked worktree")
+        let bare = temporary.appendingPathComponent("bare")
+        try git(["init", "--bare", bare.path])
+        for invalid in [temporary, temporary.appendingPathComponent("missing"), bare] {
+            do { _ = try await resolver.root(at: invalid, runtime: runtime); preconditionFailure("Expected invalid repo") }
+            catch { checks += 1 }
+        }
+        let helper = temporary.appendingPathComponent("helper")
+        try Data("#!/bin/sh\nexit 0\n".utf8).write(to: helper)
+        try manager.setAttributes([.posixPermissions: 0o755], ofItemAtPath: helper.path)
+        let installer = CommandLineInstaller(directory: temporary.appendingPathComponent("bin"), executable: helper)
+        // Keep the fixture independent of commands installed on the host.
+        setenv("PATH", "/usr/bin:/bin", 1)
+        try installer.install()
+        check(installer.isInstalled, "Installed symlink")
+        try installer.install()
+        check(installer.isInstalled, "Idempotent installation")
+        try manager.removeItem(at: installer.destination)
+        try Data("existing command".utf8).write(to: installer.destination)
+        rejects { try installer.install() }
+        check(try String(contentsOf: installer.destination, encoding: .utf8) == "existing command", "Preserve existing file")
+        try manager.removeItem(at: installer.destination)
+        try manager.createSymbolicLink(atPath: installer.destination.path, withDestinationPath: "/missing/helper")
+        rejects { try installer.install() }
+        check(try manager.destinationOfSymbolicLink(atPath: installer.destination.path) == "/missing/helper", "Preserve dangling symlink")
+        let shellHome = temporary.appendingPathComponent("shell-home")
+        try manager.createDirectory(at: shellHome, withIntermediateDirectories: true)
+        let zsh = CommandLineShellConfiguration(home: shellHome, shell: "/bin/zsh", zshDirectory: nil)
+        let zshFile = shellHome.appendingPathComponent(".zshrc")
+        let original = "# export PATH=\"$HOME/.local/bin:$PATH\"\nalias example='echo existing'\n"
+        try Data(original.utf8).write(to: zshFile)
+        check(!zsh.isConfigured, "Commented PATH is not configured")
+        try zsh.configure()
+        check(zsh.isConfigured, "Zsh PATH configured")
+        let configured = try String(contentsOf: zshFile, encoding: .utf8)
+        check(configured.hasPrefix(original), "Preserve shell configuration")
+        try zsh.configure()
+        check(try String(contentsOf: zshFile, encoding: .utf8) == configured, "PATH installation is idempotent")
+        let backups = try manager.contentsOfDirectory(at: shellHome, includingPropertiesForKeys: nil).filter { $0.lastPathComponent.contains("commitplus-backup") }
+        check(backups.count == 1, "One backup only")
+        check(try String(contentsOf: backups[0], encoding: .utf8) == original, "Backup preserves original")
+        let customZsh = CommandLineShellConfiguration(home: shellHome, shell: "/bin/zsh", zshDirectory: shellHome.appendingPathComponent("custom"))
+        try customZsh.configure()
+        check(customZsh.isConfigured, "Custom ZDOTDIR")
+        let profile = shellHome.appendingPathComponent(".profile")
+        try Data("# existing profile\n".utf8).write(to: profile)
+        let bash = CommandLineShellConfiguration(home: shellHome, shell: "/bin/bash", zshDirectory: nil)
+        try bash.configure()
+        check(bash.isConfigured && bash.files.contains(profile), "Bash uses existing login profile and bashrc")
+        check(!manager.fileExists(atPath: shellHome.appendingPathComponent(".bash_profile").path), "Do not shadow existing profile")
+        let fish = CommandLineShellConfiguration(home: shellHome, shell: "/opt/homebrew/bin/fish", zshDirectory: nil)
+        try fish.configure()
+        check(fish.isConfigured, "Fish PATH configured")
+        let unsupported = CommandLineShellConfiguration(home: shellHome, shell: "/bin/csh", zshDirectory: nil)
+        rejects { try unsupported.configure() }
+        let linkedHome = temporary.appendingPathComponent("linked-shell")
+        try manager.createDirectory(at: linkedHome, withIntermediateDirectories: true)
+        let linkedConfig = linkedHome.appendingPathComponent(".zshrc")
+        let actualConfig = linkedHome.appendingPathComponent("dotfiles-zshrc")
+        try Data(original.utf8).write(to: actualConfig)
+        try manager.createSymbolicLink(at: linkedConfig, withDestinationURL: actualConfig)
+        try CommandLineShellConfiguration(home: linkedHome, shell: "/bin/zsh", zshDirectory: nil).configure()
+        check(try manager.destinationOfSymbolicLink(atPath: linkedConfig.path) == actualConfig.path, "Keep shell config symlink")
+        check(try String(contentsOf: actualConfig, encoding: .utf8).hasPrefix(original), "Keep linked config contents")
+
+        let reminderDefaultsName = "commit-reminder-tests-\(UUID().uuidString)"
+        let reminderDefaults = UserDefaults(suiteName: reminderDefaultsName)!
+        defer { reminderDefaults.removePersistentDomain(forName: reminderDefaultsName) }
+        let firstLaunch = CommandLineReminderPolicy(defaults: reminderDefaults)
+        check(firstLaunch.claimPresentation(isReady: false), "Show for uninstalled CLI")
+        check(!firstLaunch.claimPresentation(isReady: false), "Close does not repeat within launch")
+        let nextLaunch = CommandLineReminderPolicy(defaults: reminderDefaults)
+        check(nextLaunch.claimPresentation(isReady: false), "Close reminds on next launch")
+        check(!CommandLineReminderPolicy(defaults: reminderDefaults).claimPresentation(isReady: true), "Skip installed CLI and PATH")
+        nextLaunch.dontRemind()
+        check(!CommandLineReminderPolicy(defaults: reminderDefaults).claimPresentation(isReady: false), "Don't remind persists across launches")
+        let setup = CommandLineSetupModel(
+            installer: CommandLineInstaller(directory: shellHome.appendingPathComponent(".local/bin"), executable: helper),
+            shellConfiguration: zsh
+        )
+        setup.install()
+        check(setup.isReady && setup.errorMessage == nil, "One button completes CLI and PATH installation")
+        print("Passed \(checks) CLI, resolver, URL, and installation checks.")
+    }
+}

--- a/command-line/inputs.xcfilelist
+++ b/command-line/inputs.xcfilelist
@@ -1,0 +1,10 @@
+$(SRCROOT)/scripts/build-command-line.sh
+$(SRCROOT)/command-line/CommitCommand.swift
+$(SRCROOT)/macgit/Services/RepositoryOpenRequest.swift
+$(SRCROOT)/macgit/Services/RepositoryOpenError.swift
+$(SRCROOT)/macgit/Services/RepositoryPathResolver.swift
+$(SRCROOT)/macgit/Services/GitRuntimeManager.swift
+$(SRCROOT)/macgit/Services/GitRuntimeManifest.swift
+$(SRCROOT)/macgit/Services/GitRuntimeError.swift
+$(SRCROOT)/macgit/Models/GitRuntimePreference.swift
+$(SRCROOT)/macgit/Models/GitRuntimeStatus.swift

--- a/docs/superpowers/plans/2026-09-10-terminal-open-implementation.md
+++ b/docs/superpowers/plans/2026-09-10-terminal-open-implementation.md
@@ -1,0 +1,41 @@
+# Terminal repository opening implementation
+
+1. Build a signed native helper in Contents/Helpers, sharing runtime selection and repository validation with the app.
+2. Add a strict macgit://open-repository URL route, preserving authentication callbacks.
+3. Resolve repository roots with Git, including subfolders, empty repositories and worktrees; preserve literal paths and reject invalid folders.
+4. Install a symlink at ~/.local/bin/commit from General Settings, without overwriting existing commands. Show PATH guidance.
+5. Test parser, resolver and installation in isolation, build the macOS app and inspect packaged helper. Do not launch the app.
+
+The helper returns success when macOS accepts the open request. Errors after handoff appear in the app. Bare repositories are unsupported. Embedded Git remains the existing optional downloaded runtime; the CLI honors the app's runtime preference.
+
+## Build integration
+
+The app build phase compiles each requested architecture, combines them with lipo,
+and signs the nested helper before the app is signed. Script sandboxing is disabled
+for this app target because the Swift compiler creates its own module-cache files.
+This does not change the app's runtime sandbox or hardened-runtime settings.
+
+## Verification
+
+- 26 isolated parser, URL round-trip, real Git repository/worktree, inherited Git
+  environment, and installation checks passed via `bash scripts/test-command-line.sh`.
+- The packaged helper passed strict signature verification, help output, PATH-style
+  argv[0] lookup, and nonzero stderr checks for non-repos, missing folders and invalid
+  arguments. These checks do not launch the app.
+- `xcodebuild build` passed after integration.
+- Window activation, cold-launch routing and Settings interaction still require a
+  manual check; the app was not launched, following repository instructions.
+
+## Launch setup tip and automatic PATH configuration
+
+- Offer one setup tip per process launch, after other startup sheets are dismissed.
+- Close only dismisses this launch; Don't remind stores a local suppression flag.
+- Skip the tip when the CLI symlink and shell configuration are both installed.
+- One button installs the helper and appends the PATH command, backing up existing
+  zsh/bash/fish configuration and preserving symlinks. Settings shares the same setup model.
+- Display installation errors in the tip, retain a retry button for partial setup,
+  and explain that existing terminal sessions need the displayed command or a new tab.
+- Validate reminder policy, shell configuration, repeated installation and preservation
+  with the standalone CLI harness; build without launching the app.
+
+Validation after setup-tip integration: 45 standalone checks passed; final macOS build succeeded. The app was not launched, so modal appearance and interaction remain manually unverified.

--- a/docs/superpowers/plans/2026-09-10-terminal-open-roadmap.md
+++ b/docs/superpowers/plans/2026-09-10-terminal-open-roadmap.md
@@ -1,0 +1,7 @@
+# Terminal repository opening roadmap
+
+- [completed] [CLI, URL routing, installation and verification](2026-09-10-terminal-open-implementation.md)
+
+Authorized behavior: `commit`, `commit .`, or `commit <folder>` validates a Git working tree in Terminal before asking Commit+ to open it. Invalid folders return stderr and nonzero status without launching the app. The app revalidates incoming URLs. Existing repository windows are focused; otherwise use the receiving empty window or open another window.
+
+- [completed] [Launch setup tip and automatic shell PATH configuration](2026-09-10-terminal-open-implementation.md#launch-setup-tip-and-automatic-path-configuration).

--- a/macgit.xcodeproj/project.pbxproj
+++ b/macgit.xcodeproj/project.pbxproj
@@ -95,6 +95,7 @@
 				6A843CA12FC5342F0031F230 /* Sources */,
 				6A843CA22FC5342F0031F230 /* Frameworks */,
 				6A843CA32FC5342F0031F230 /* Resources */,
+				C01117012FE0000100A1B2C3 /* Build commit command */,
 			);
 			buildRules = (
 			);
@@ -192,6 +193,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+        C01117012FE0000100A1B2C3 /* Build commit command */ = {
+            isa = PBXShellScriptBuildPhase;
+            buildActionMask = 2147483647;
+            files = ();
+            inputFileListPaths = ("$(SRCROOT)/command-line/inputs.xcfilelist");
+            name = "Build commit command";
+            outputPaths = (
+                "$(TARGET_BUILD_DIR)/$(CONTENTS_FOLDER_PATH)/Helpers/commit",
+                "$(DERIVED_FILE_DIR)/CommitCLI",
+            );
+            runOnlyForDeploymentPostprocessing = 0;
+            shellPath = /bin/bash;
+            shellScript = "bash \"$SRCROOT/scripts/build-command-line.sh\"";
+        };
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		6A843CA12FC5342F0031F230 /* Sources */ = {
@@ -377,6 +395,7 @@
 					AVFoundation,
 					"-ObjC",
 				);
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.thanhtran.macgit;
 				PRODUCT_MODULE_NAME = macgit;
 				PRODUCT_NAME = "Commit+";
@@ -436,6 +455,7 @@
 					AVFoundation,
 					"-ObjC",
 				);
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.thanhtran.macgit;
 				PRODUCT_MODULE_NAME = macgit;
 				PRODUCT_NAME = "Commit+";

--- a/macgit/App/RepositoryWindowContext.swift
+++ b/macgit/App/RepositoryWindowContext.swift
@@ -19,7 +19,36 @@
 import AppKit
 @MainActor
 final class RepositoryWindowContext {
+    private static let contexts = NSHashTable<RepositoryWindowContext>.weakObjects()
+    private static var pendingRepositories = Set<URL>()
     weak var window: NSWindow?
+    var repositoryURL: URL? {
+        didSet {
+            if let repositoryURL {
+                Self.pendingRepositories.remove(repositoryURL.resolvingSymlinksInPath().standardizedFileURL)
+            }
+        }
+    }
+
+    static func reserveOpening(_ url: URL) -> Bool {
+        pendingRepositories.insert(url).inserted
+    }
+
+    init() {
+        Self.contexts.add(self)
+    }
+
+    static func focusRepository(at url: URL) -> Bool {
+        guard let context = contexts.allObjects.first(where: {
+            $0.repositoryURL?.resolvingSymlinksInPath().standardizedFileURL == url
+                && ($0.window?.isVisible == true || $0.window?.isMiniaturized == true
+                    || $0.window?.tabGroup?.windows.contains(where: { $0.isVisible || $0.isMiniaturized }) == true)
+        }), let window = context.window else { return false }
+        window.deminiaturize(nil)
+        window.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
+        return true
+    }
 
     func owns(_ notification: Notification) -> Bool {
         guard let targetWindow = notification.object as? NSWindow else { return false }

--- a/macgit/App/RepositoryWindowReader.swift
+++ b/macgit/App/RepositoryWindowReader.swift
@@ -22,15 +22,18 @@ import SwiftUI
 struct RepositoryWindowReader: NSViewRepresentable {
     let repositoryWindowContext: RepositoryWindowContext
     let title: String
+    var repositoryURL: URL? = nil
 
     func makeNSView(context: Context) -> WindowReaderView {
-        WindowReaderView(
+        repositoryWindowContext.repositoryURL = repositoryURL
+        return WindowReaderView(
             repositoryWindowContext: repositoryWindowContext,
             title: title
         )
     }
 
     func updateNSView(_ nsView: WindowReaderView, context: Context) {
+        repositoryWindowContext.repositoryURL = repositoryURL
         nsView.repositoryWindowContext = repositoryWindowContext
         nsView.title = title
         nsView.configureWindow()

--- a/macgit/App/macgitApp.swift
+++ b/macgit/App/macgitApp.swift
@@ -188,7 +188,8 @@ struct macgitApp: App {
                 request: request.wrappedValue,
                 accountController: accountController,
                 providerAccountController: providerAccountController,
-                aiProviderController: aiProviderController
+                aiProviderController: aiProviderController,
+                isShowingAppSettings: showingAppSettings
             )
                 .environmentObject(appState)
                 .environmentObject(appUpdateController)
@@ -197,17 +198,6 @@ struct macgitApp: App {
                 .environmentObject(repositoryBookmarkController)
                 .environmentObject(gitFlowConfigurationSyncController)
                 .preferredColorScheme(appState.appearance.colorScheme)
-                .onOpenURL { url in
-                    Task { @MainActor in
-                        if await accountController.handleWebSignInCallback(url) {
-                            return
-                        }
-                        if await providerAccountController.handleProviderOAuthCallback(url) {
-                            return
-                        }
-                        _ = GIDSignIn.sharedInstance.handle(url)
-                    }
-                }
                 .task {
                     appUpdateController.start()
                 }

--- a/macgit/Services/CommandLineInstaller.swift
+++ b/macgit/Services/CommandLineInstaller.swift
@@ -1,0 +1,63 @@
+//
+//  macgit (Commit+) - a macOS Git client built with Swift and SwiftUI.
+//  Copyright (C) 2026  Thanh Tran <trantienthanh2412@gmail.com>
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Affero General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Affero General Public License for more details.
+//
+//  You should have received a copy of the GNU Affero General Public License
+//  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Foundation
+
+struct CommandLineInstaller {
+    let directory: URL
+    let executable: URL
+
+    init(directory: URL = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".local/bin"),
+         executable: URL = Bundle.main.bundleURL.appendingPathComponent("Contents/Helpers/commit")) {
+        self.directory = directory
+        self.executable = executable
+    }
+
+    var destination: URL { directory.appendingPathComponent("commit") }
+
+    var isInstalled: Bool {
+        guard let target = try? FileManager.default.destinationOfSymbolicLink(atPath: destination.path) else { return false }
+        return target == executable.path && FileManager.default.isExecutableFile(atPath: executable.path)
+    }
+
+    var conflict: String? {
+        let manager = FileManager.default
+        if (try? manager.attributesOfItem(atPath: destination.path)) != nil, !isInstalled {
+            return "A different file or command already exists at \(destination.path). Move it before installing."
+        }
+        for directory in (ProcessInfo.processInfo.environment["PATH"] ?? "").split(separator: ":") {
+            let candidate = URL(fileURLWithPath: String(directory)).appendingPathComponent("commit")
+            if candidate.standardizedFileURL != destination.standardizedFileURL,
+               manager.isExecutableFile(atPath: candidate.path) {
+                return "Another commit command exists at \(candidate.path). Resolve the name conflict before installing."
+            }
+        }
+        return nil
+    }
+
+    func install() throws {
+        if isInstalled { return }
+        if let conflict { throw RepositoryOpenError.message(conflict) }
+        guard FileManager.default.isExecutableFile(atPath: executable.path) else {
+            throw RepositoryOpenError.message("The command is missing from this app bundle. Reinstall Commit+.")
+        }
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        // Exclusive creation: never replace a file, command, or symlink that appeared in the meantime.
+        try FileManager.default.createSymbolicLink(at: destination, withDestinationURL: executable)
+    }
+}

--- a/macgit/Services/CommandLineReminderPolicy.swift
+++ b/macgit/Services/CommandLineReminderPolicy.swift
@@ -1,0 +1,42 @@
+//
+//  macgit (Commit+) - a macOS Git client built with Swift and SwiftUI.
+//  Copyright (C) 2026  Thanh Tran <trantienthanh2412@gmail.com>
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Affero General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Affero General Public License for more details.
+//
+//  You should have received a copy of the GNU Affero General Public License
+//  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Foundation
+
+@MainActor
+final class CommandLineReminderPolicy {
+    static let shared = CommandLineReminderPolicy()
+    private let defaults: UserDefaults
+    private var presentedThisLaunch = false
+    private static let suppressionKey = "commandLineSetupDontRemind"
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    func claimPresentation(isReady: Bool) -> Bool {
+        guard !isReady, !presentedThisLaunch,
+              !defaults.bool(forKey: Self.suppressionKey) else { return false }
+        presentedThisLaunch = true
+        return true
+    }
+
+    func dontRemind() {
+        defaults.set(true, forKey: Self.suppressionKey)
+    }
+}

--- a/macgit/Services/CommandLineShellConfiguration.swift
+++ b/macgit/Services/CommandLineShellConfiguration.swift
@@ -1,0 +1,96 @@
+//
+//  macgit (Commit+) - a macOS Git client built with Swift and SwiftUI.
+//  Copyright (C) 2026  Thanh Tran <trantienthanh2412@gmail.com>
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Affero General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Affero General Public License for more details.
+//
+//  You should have received a copy of the GNU Affero General Public License
+//  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Foundation
+import Darwin
+
+struct CommandLineShellConfiguration {
+    let home: URL
+    let shell: String
+    let zshDirectory: URL?
+
+    init(home: URL = FileManager.default.homeDirectoryForCurrentUser,
+         shell: String? = nil,
+         zshDirectory: URL? = ProcessInfo.processInfo.environment["ZDOTDIR"].map { URL(fileURLWithPath: $0) }) {
+        self.home = home
+        self.shell = shell ?? getpwuid(getuid()).flatMap { $0.pointee.pw_shell }.map { String(cString: $0) } ?? "/bin/zsh"
+        self.zshDirectory = zshDirectory
+    }
+
+    var command: String {
+        shell.hasSuffix("/fish")
+            ? "set -gx PATH \"$HOME/.local/bin\" $PATH"
+            : "export PATH=\"$HOME/.local/bin:$PATH\""
+    }
+
+    var files: [URL] {
+        switch URL(fileURLWithPath: shell).lastPathComponent {
+        case "zsh":
+            return [(zshDirectory ?? home).appendingPathComponent(".zshrc")]
+        case "bash":
+            let loginNames = [".bash_profile", ".bash_login", ".profile"]
+            let login = loginNames.first { FileManager.default.fileExists(atPath: home.appendingPathComponent($0).path) } ?? ".bash_profile"
+            return [home.appendingPathComponent(login), home.appendingPathComponent(".bashrc")]
+        case "fish":
+            return [home.appendingPathComponent(".config/fish/config.fish")]
+        default:
+            return []
+        }
+    }
+
+    var isConfigured: Bool {
+        !files.isEmpty && files.allSatisfy { url in
+            guard let content = try? String(contentsOf: url, encoding: .utf8) else { return false }
+            return containsConfiguration(content)
+        }
+    }
+
+    private func containsConfiguration(_ content: String) -> Bool {
+        content.split(separator: "\n").contains { line in
+            line.trimmingCharacters(in: .whitespaces) == command
+        }
+    }
+
+    func configure() throws {
+        guard !files.isEmpty else {
+            throw RepositoryOpenError.message("Automatic PATH setup is not supported for \(shell). Add ~/.local/bin to your shell's PATH manually.")
+        }
+        let manager = FileManager.default
+        for file in files {
+            let exists = manager.fileExists(atPath: file.path)
+            let content = exists ? try String(contentsOf: file, encoding: .utf8) : ""
+            if containsConfiguration(content) { continue }
+            try manager.createDirectory(at: file.deletingLastPathComponent(), withIntermediateDirectories: true)
+            if exists {
+                let backup = file.appendingPathExtension("commitplus-backup-\(UUID().uuidString)")
+                let descriptor = open(backup.path, O_WRONLY | O_CREAT | O_EXCL, S_IRUSR | S_IWUSR)
+                guard descriptor >= 0 else { throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO) }
+                let backupHandle = FileHandle(fileDescriptor: descriptor, closeOnDealloc: true)
+                defer { try? backupHandle.close() }
+                try backupHandle.write(contentsOf: Data(content.utf8))
+            } else {
+                try Data().write(to: file, options: .withoutOverwriting)
+            }
+            // Append through the existing file, preserving shell-config symlinks and permissions.
+            let handle = try FileHandle(forWritingTo: file)
+            defer { try? handle.close() }
+            try handle.seekToEnd()
+            try handle.write(contentsOf: Data("\n# Commit+ command line tools\n\(command)\n".utf8))
+        }
+    }
+}

--- a/macgit/Services/RepositoryOpenError.swift
+++ b/macgit/Services/RepositoryOpenError.swift
@@ -1,0 +1,29 @@
+//
+//  macgit (Commit+) - a macOS Git client built with Swift and SwiftUI.
+//  Copyright (C) 2026  Thanh Tran <trantienthanh2412@gmail.com>
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Affero General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Affero General Public License for more details.
+//
+//  You should have received a copy of the GNU Affero General Public License
+//  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Foundation
+
+nonisolated enum RepositoryOpenError: LocalizedError {
+    case message(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .message(let message): message
+        }
+    }
+}

--- a/macgit/Services/RepositoryOpenRequest.swift
+++ b/macgit/Services/RepositoryOpenRequest.swift
@@ -1,0 +1,63 @@
+//
+//  macgit (Commit+) - a macOS Git client built with Swift and SwiftUI.
+//  Copyright (C) 2026  Thanh Tran <trantienthanh2412@gmail.com>
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Affero General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Affero General Public License for more details.
+//
+//  You should have received a copy of the GNU Affero General Public License
+//  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Foundation
+
+nonisolated enum RepositoryOpenRequest {
+    static func recognizes(_ url: URL) -> Bool {
+        url.scheme == "macgit" && url.host == "open-repository"
+    }
+
+    static func repositoryURL(from url: URL) throws -> URL {
+        guard recognizes(url),
+              let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+              components.user == nil, components.password == nil, components.port == nil,
+              components.path.isEmpty, components.fragment == nil,
+              let items = components.queryItems, items.count == 1,
+              items[0].name == "path", let path = items[0].value,
+              path.hasPrefix("/"), !path.contains("\0") else {
+            throw RepositoryOpenError.message("Invalid repository URL. Expected an absolute folder path.")
+        }
+        return URL(fileURLWithPath: path, isDirectory: true)
+    }
+
+    static func url(for repositoryURL: URL) -> URL {
+        var components = URLComponents()
+        components.scheme = "macgit"
+        components.host = "open-repository"
+        components.queryItems = [URLQueryItem(name: "path", value: repositoryURL.path)]
+        return components.url!
+    }
+
+    static func directory(arguments: [String], currentDirectory: String) throws -> URL {
+        var paths = arguments
+        if paths.first == "--" { paths.removeFirst() }
+        else if paths.first?.hasPrefix("-") == true {
+            throw RepositoryOpenError.message("Unknown option. Usage: commit [<folder>] (use -- before a path starting with '-').")
+        }
+        guard paths.count <= 1 else {
+            throw RepositoryOpenError.message("Usage: commit [<folder>]")
+        }
+        let path = paths.first ?? "."
+        guard !path.isEmpty, !path.contains("\0") else {
+            throw RepositoryOpenError.message("Expected a folder path.")
+        }
+        return URL(fileURLWithPath: path, isDirectory: true,
+                   relativeTo: URL(fileURLWithPath: currentDirectory, isDirectory: true)).standardizedFileURL
+    }
+}

--- a/macgit/Services/RepositoryPathResolver.swift
+++ b/macgit/Services/RepositoryPathResolver.swift
@@ -1,0 +1,75 @@
+//
+//  macgit (Commit+) - a macOS Git client built with Swift and SwiftUI.
+//  Copyright (C) 2026  Thanh Tran <trantienthanh2412@gmail.com>
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Affero General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Affero General Public License for more details.
+//
+//  You should have received a copy of the GNU Affero General Public License
+//  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Foundation
+
+actor RepositoryPathResolver {
+    func root(at directory: URL, runtime: GitRuntimeManager = .shared) async throws -> URL {
+        var isDirectory: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: directory.path, isDirectory: &isDirectory),
+              isDirectory.boolValue else {
+            throw RepositoryOpenError.message("'\(directory.path)' is not an existing folder.")
+        }
+        guard FileManager.default.isReadableFile(atPath: directory.path) else {
+            throw RepositoryOpenError.message("Cannot read '\(directory.path)'.")
+        }
+        let executable = try await runtime.executableURL()
+        var environment = await runtime.environment(
+            for: executable, inheriting: ProcessInfo.processInfo.environment
+        )
+        // The explicit folder owns discovery, even inside a Git hook or shell with Git overrides.
+        for key in environment.keys where key.hasPrefix("GIT_") {
+            if !["GIT_EXEC_PATH", "GIT_CONFIG_SYSTEM", "GIT_TEMPLATE_DIR"].contains(key) {
+                environment.removeValue(forKey: key)
+            }
+        }
+        let process = Process()
+        process.executableURL = executable
+        process.arguments = ["-C", directory.path, "rev-parse", "--show-toplevel"]
+        process.environment = environment
+        let output = Pipe()
+        process.standardOutput = output
+        // Keep Git's diagnostic (permissions, unsafe ownership, corrupt metadata) for the caller.
+        let errorURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        FileManager.default.createFile(atPath: errorURL.path, contents: nil,
+                                       attributes: [.posixPermissions: 0o600])
+        let errorFile = try FileHandle(forWritingTo: errorURL)
+        defer {
+            try? errorFile.close()
+            try? FileManager.default.removeItem(at: errorURL)
+        }
+        process.standardError = errorFile
+        try process.run()
+        let data = output.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+        guard process.terminationStatus == 0 else {
+            let diagnostic = (try? String(contentsOf: errorURL, encoding: .utf8)) ?? ""
+            throw RepositoryOpenError.message(
+                "Cannot open '\(directory.path)' as a Git working tree. " + diagnostic.trimmingCharacters(in: .newlines)
+            )
+        }
+        guard var path = String(data: data, encoding: .utf8), path.hasSuffix("\n") else {
+            throw RepositoryOpenError.message("Git returned an invalid repository path.")
+        }
+        path.removeLast() // Preserve spaces and newlines that belong to the filename.
+        guard path.hasPrefix("/") else {
+            throw RepositoryOpenError.message("Git returned an invalid repository path.")
+        }
+        return URL(fileURLWithPath: path, isDirectory: true).resolvingSymlinksInPath().standardizedFileURL
+    }
+}

--- a/macgit/ViewModels/CommandLineSetupModel.swift
+++ b/macgit/ViewModels/CommandLineSetupModel.swift
@@ -1,0 +1,56 @@
+//
+//  macgit (Commit+) - a macOS Git client built with Swift and SwiftUI.
+//  Copyright (C) 2026  Thanh Tran <trantienthanh2412@gmail.com>
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Affero General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Affero General Public License for more details.
+//
+//  You should have received a copy of the GNU Affero General Public License
+//  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Foundation
+import Observation
+
+@MainActor
+@Observable
+final class CommandLineSetupModel {
+    private let installer: CommandLineInstaller
+    let shellConfiguration: CommandLineShellConfiguration
+    private(set) var isInstalled = false
+    private(set) var isReady = false
+    private(set) var errorMessage: String?
+
+    init(installer: CommandLineInstaller = CommandLineInstaller(),
+         shellConfiguration: CommandLineShellConfiguration = CommandLineShellConfiguration()) {
+        self.installer = installer
+        self.shellConfiguration = shellConfiguration
+        refresh()
+    }
+
+    var destination: URL { installer.destination }
+
+    func refresh() {
+        isInstalled = installer.isInstalled
+        isReady = isInstalled && shellConfiguration.isConfigured
+        errorMessage = installer.conflict
+    }
+
+    func install() {
+        do {
+            try installer.install()
+            try shellConfiguration.configure()
+            refresh()
+        } catch {
+            refresh()
+            errorMessage = error.localizedDescription
+        }
+    }
+}

--- a/macgit/Views/Common/CommandLineSettingsSection.swift
+++ b/macgit/Views/Common/CommandLineSettingsSection.swift
@@ -1,0 +1,67 @@
+//
+//  macgit (Commit+) - a macOS Git client built with Swift and SwiftUI.
+//  Copyright (C) 2026  Thanh Tran <trantienthanh2412@gmail.com>
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Affero General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Affero General Public License for more details.
+//
+//  You should have received a copy of the GNU Affero General Public License
+//  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import SwiftUI
+
+struct CommandLineSettingsSection: View {
+    @State private var model = CommandLineSetupModel()
+    @State private var copiedCommand: String?
+
+    var body: some View {
+        Section {
+            Text("Open a repository from Terminal with commit or commit .")
+            LabeledContent("Command", value: model.destination.path)
+            if model.isReady {
+                Label("CLI and PATH installed", systemImage: "checkmark.circle.fill")
+                    .foregroundStyle(.green)
+            } else {
+                Button(model.isInstalled ? "Configure PATH" : "Install CLI & Configure PATH", action: model.install)
+                    .buttonStyle(.borderedProminent)
+            }
+            Text("Installation adds PATH to your shell configuration and backs up existing files. Open a new terminal afterward, or run this in your current terminal:")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+            CommandLineCodeBlock(
+                command: model.shellConfiguration.command,
+                copiedCommand: $copiedCommand
+            )
+            HStack(alignment: .firstTextBaseline, spacing: 4) {
+                Text("After installation, open a repository folder in Terminal and run")
+                Text("commit .")
+                    .font(.system(.callout, design: .monospaced).bold())
+                    .foregroundStyle(.primary)
+                    .padding(.horizontal, 4)
+                    .padding(.vertical, 2)
+                    .background(.quaternary, in: RoundedRectangle(cornerRadius: 4))
+                Text("to open it in Commit+.")
+            }
+            .font(.callout)
+            .foregroundStyle(.secondary)
+            .fixedSize(horizontal: false, vertical: true)
+            Text("Run command -v commit in Terminal to check which command your shell uses. Existing aliases and functions may take precedence.")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+            if let message = model.errorMessage {
+                Text(message).foregroundStyle(.red).textSelection(.enabled)
+            }
+        } header: {
+            Label("Command Line", systemImage: "terminal")
+        }
+        .onAppear(perform: model.refresh)
+    }
+}

--- a/macgit/Views/Common/CommandLineSetupTip.swift
+++ b/macgit/Views/Common/CommandLineSetupTip.swift
@@ -1,0 +1,140 @@
+//
+//  macgit (Commit+) - a macOS Git client built with Swift and SwiftUI.
+//  Copyright (C) 2026  Thanh Tran <trantienthanh2412@gmail.com>
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Affero General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Affero General Public License for more details.
+//
+//  You should have received a copy of the GNU Affero General Public License
+//  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import AppKit
+import SwiftUI
+
+struct CommandLineSetupTip: View {
+    @Environment(\.dismiss) private var dismiss
+    @State private var model = CommandLineSetupModel()
+    @State private var copiedCommand: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 18) {
+            Label("Open repositories from Terminal", systemImage: "terminal")
+                .font(.title2.bold())
+            Text("Type commit or commit . inside a repository to open it in Commit+.")
+                .foregroundStyle(.secondary)
+
+            VStack(alignment: .leading, spacing: 10) {
+                if model.isReady {
+                    Label("CLI and PATH are installed", systemImage: "checkmark.circle.fill")
+                        .foregroundStyle(.green)
+                    Text("Open a new terminal tab or window to use commit.")
+                } else {
+                    Button("Install CLI & Configure PATH", action: model.install)
+                        .buttonStyle(.borderedProminent)
+                    Text("Creates ~/.local/bin/commit and adds PATH to your shell configuration. Existing configuration is kept and backed up.")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                }
+                if let error = model.errorMessage {
+                    Text(error).foregroundStyle(.red).textSelection(.enabled)
+                }
+            }
+            .padding(16)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(.quaternary.opacity(0.45), in: RoundedRectangle(cornerRadius: 12))
+
+            Divider()
+            VStack(alignment: .leading, spacing: 14) {
+                Text("Step by step").font(.headline)
+                Text("1. Click Install CLI & Configure PATH above.")
+                Text("2. Open a new terminal. To use your current terminal immediately, run:")
+                CommandLineCodeBlock(
+                    command: model.shellConfiguration.command,
+                    copiedCommand: $copiedCommand
+                )
+                Text("3. Go to your repository folder and run:")
+                CommandLineCodeBlock(command: "commit .", copiedCommand: $copiedCommand)
+                Text("You can also install it later in Settings → General → Command Line.")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+            }
+
+            HStack(spacing: 10) {
+                Spacer()
+                Button("Close") { dismiss() }
+                    .keyboardShortcut(.cancelAction)
+                Button("Don't remind", action: dontRemind)
+                    .buttonStyle(.borderedProminent)
+            }
+        }
+        .padding(24)
+        .frame(width: 540)
+    }
+
+    private func dontRemind() {
+        CommandLineReminderPolicy.shared.dontRemind()
+        dismiss()
+    }
+}
+
+struct CommandLineCodeBlock: View {
+    let command: String
+    @Binding var copiedCommand: String?
+
+    var body: some View {
+        HStack(spacing: 10) {
+            syntaxColoredCommand
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .textSelection(.enabled)
+
+            Button {
+                copyCommand()
+            } label: {
+                Image(systemName: copiedCommand == command ? "checkmark" : "doc.on.doc")
+                    .foregroundStyle(copiedCommand == command ? .green : .secondary)
+                    .contentTransition(.symbolEffect(.replace))
+            }
+            .buttonStyle(.plain)
+            .help("Copy command")
+            .accessibilityLabel(copiedCommand == command ? "Copied" : "Copy command")
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 11)
+        .background(Color.black.opacity(0.28), in: RoundedRectangle(cornerRadius: 9))
+        .overlay {
+            RoundedRectangle(cornerRadius: 9)
+                .strokeBorder(.white.opacity(0.08))
+        }
+    }
+
+    private var syntaxColoredCommand: Text {
+        let prompt = Text("❯ ").foregroundStyle(.secondary)
+        if command.hasPrefix("export PATH=") {
+            return prompt
+                + Text("export").foregroundStyle(.purple)
+                + Text(" PATH=").foregroundStyle(.primary)
+                + Text("\"$HOME/.local/bin:$PATH\"").foregroundStyle(.orange)
+        }
+        return prompt + Text("commit").foregroundStyle(.blue) + Text(" .").foregroundStyle(.primary)
+    }
+
+    private func copyCommand() {
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(command, forType: .string)
+        copiedCommand = command
+        Task { @MainActor in
+            try? await Task.sleep(nanoseconds: 2_000_000_000)
+            if copiedCommand == command {
+                copiedCommand = nil
+            }
+        }
+    }
+}

--- a/macgit/Views/Common/CommandLineSetupTipModifier.swift
+++ b/macgit/Views/Common/CommandLineSetupTipModifier.swift
@@ -1,0 +1,44 @@
+//
+//  macgit (Commit+) - a macOS Git client built with Swift and SwiftUI.
+//  Copyright (C) 2026  Thanh Tran <trantienthanh2412@gmail.com>
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Affero General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Affero General Public License for more details.
+//
+//  You should have received a copy of the GNU Affero General Public License
+//  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import SwiftUI
+
+struct CommandLineSetupTipModifier: ViewModifier {
+    let isBlocked: Bool
+    @Environment(\.scenePhase) private var scenePhase
+    @State private var showingTip = false
+
+    func body(content: Content) -> some View {
+        content
+            .sheet(isPresented: $showingTip) {
+                CommandLineSetupTip()
+            }
+            .task {
+                await Task.yield()
+                presentIfNeeded()
+            }
+            .onChange(of: isBlocked) { _, _ in presentIfNeeded() }
+            .onChange(of: scenePhase) { _, _ in presentIfNeeded() }
+    }
+
+    private func presentIfNeeded() {
+        guard !isBlocked, scenePhase == .active else { return }
+        let model = CommandLineSetupModel()
+        showingTip = showingTip || CommandLineReminderPolicy.shared.claimPresentation(isReady: model.isReady)
+    }
+}

--- a/macgit/Views/Common/GeneralSettingsView.swift
+++ b/macgit/Views/Common/GeneralSettingsView.swift
@@ -71,6 +71,8 @@ struct GeneralSettingsView: View {
                 Label("Pull & Fetch", systemImage: "arrow.triangle.2.circlepath")
             }
 
+            CommandLineSettingsSection()
+
             Section {
                 Button("Restore General Defaults…", action: showResetConfirmation)
             }

--- a/macgit/Views/MainWindow/ContentView.swift
+++ b/macgit/Views/MainWindow/ContentView.swift
@@ -16,6 +16,7 @@
 //  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 //
 import SwiftUI
+import GoogleSignIn
 
 struct ContentView: View {
     @EnvironmentObject private var repositoryBookmarkController: RepositoryBookmarkController
@@ -23,7 +24,11 @@ struct ContentView: View {
     @ObservedObject var accountController: AccountSessionController
     @ObservedObject var providerAccountController: GitProviderAccountController
     @ObservedObject var aiProviderController: AIProviderController
+    let isShowingAppSettings: Bool
 
+    @State private var repositoryOpenError = ""
+    @State private var showingRepositoryOpenError = false
+    @State private var externalOpenTask: Task<Void, Never>?
     @State private var repositoryURL: URL?
     @State private var showingRepoPickerSheet = false
     @State private var showingCloneSheet = false
@@ -38,11 +43,13 @@ struct ContentView: View {
         request: RepositoryWindowRequest?,
         accountController: AccountSessionController,
         providerAccountController: GitProviderAccountController,
-        aiProviderController: AIProviderController
+        aiProviderController: AIProviderController,
+        isShowingAppSettings: Bool = false
     ) {
         self.accountController = accountController
         self.providerAccountController = providerAccountController
         self.aiProviderController = aiProviderController
+        self.isShowingAppSettings = isShowingAppSettings
         _repositoryURL = State(initialValue: request?.repositoryURL)
         _showingCloneSheet = State(
             initialValue: request?.initialPresentation == .cloneRepository
@@ -77,6 +84,11 @@ struct ContentView: View {
                     }
                 )
             }
+        }
+        .onOpenURL(perform: handleExternalURL)
+        .alert("Cannot Open Repository", isPresented: $showingRepositoryOpenError) {
+        } message: {
+            Text(repositoryOpenError)
         }
         .overlay {
             if repositoryURL == nil, let operation = webOpeningOperation {
@@ -167,7 +179,8 @@ struct ContentView: View {
         .background(
             RepositoryWindowReader(
                 repositoryWindowContext: windowContext,
-                title: repositoryURL?.lastPathComponent ?? "Commit+"
+                title: repositoryURL?.lastPathComponent ?? "Commit+",
+                repositoryURL: repositoryURL
             )
         )
         .focusedSceneValue(
@@ -180,14 +193,55 @@ struct ContentView: View {
         // Prefer the scene that opened browser sign-in. If it was closed (or the
         // app relaunched), allow another existing scene to receive the callback.
         .handlesExternalEvents(
-            preferring: accountController.webSignInWindowNumber != nil
-                && accountController.webSignInWindowNumber == windowContext.window?.windowNumber
-                ? ["macgit://session"] : [],
-            allowing: ["macgit://session"]
+            preferring: preferredExternalEvents,
+            allowing: ["macgit://session", "macgit://open-repository"]
         )
         .windowDismissBehavior(
             operationProgress.activeOperation == nil ? .automatic : .disabled
         )
+        .modifier(CommandLineSetupTipModifier(
+            isBlocked: isShowingAppSettings || showingCloneSheet || showingRepoPickerSheet
+                || showingKeepCurrentAlert || accountController.presentedSheet != nil
+                || operationProgress.activeOperation != nil
+        ))
+    }
+
+    private var preferredExternalEvents: Set<String> {
+        var events: Set<String> = repositoryURL == nil ? ["macgit://open-repository"] : []
+        if accountController.webSignInWindowNumber != nil,
+           accountController.webSignInWindowNumber == windowContext.window?.windowNumber {
+            events.insert("macgit://session")
+        }
+        return events
+    }
+
+    private func handleExternalURL(_ url: URL) {
+        guard RepositoryOpenRequest.recognizes(url) else {
+            Task { @MainActor in
+                if await accountController.handleWebSignInCallback(url) { return }
+                if await providerAccountController.handleProviderOAuthCallback(url) { return }
+                _ = GIDSignIn.sharedInstance.handle(url)
+            }
+            return
+        }
+        // Serialize requests delivered to this scene, including repeated commands during launch.
+        let previousTask = externalOpenTask
+        externalOpenTask = Task { @MainActor in
+            await previousTask?.value
+            do {
+                let directory = try RepositoryOpenRequest.repositoryURL(from: url)
+                let root = try await RepositoryPathResolver().root(at: directory)
+                if RepositoryWindowContext.focusRepository(at: root) { return }
+                if repositoryURL?.resolvingSymlinksInPath().standardizedFileURL == root { return }
+                guard RepositoryWindowContext.reserveOpening(root) else { return }
+                RecentRepositoriesStore.shared.add(root)
+                openRepository(root, inNewWindow: repositoryURL != nil)
+                NSApp.activate(ignoringOtherApps: true)
+            } catch {
+                repositoryOpenError = error.localizedDescription
+                showingRepositoryOpenError = true
+            }
+        }
     }
 
     private var webOpeningOperation: RepositoryOperationProgressItem? {

--- a/scripts/build-command-line.sh
+++ b/scripts/build-command-line.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -euo pipefail
+
+cli_work="$DERIVED_FILE_DIR/CommitCLI"
+cli_output="$TARGET_BUILD_DIR/$CONTENTS_FOLDER_PATH/Helpers/commit"
+mkdir -p "$cli_work" "$(dirname "$cli_output")"
+cli_sources=(
+  "$SRCROOT/command-line/CommitCommand.swift"
+  "$SRCROOT/macgit/Services/RepositoryOpenRequest.swift"
+  "$SRCROOT/macgit/Services/RepositoryOpenError.swift"
+  "$SRCROOT/macgit/Services/RepositoryPathResolver.swift"
+  "$SRCROOT/macgit/Services/GitRuntimeManager.swift"
+  "$SRCROOT/macgit/Services/GitRuntimeManifest.swift"
+  "$SRCROOT/macgit/Services/GitRuntimeError.swift"
+  "$SRCROOT/macgit/Models/GitRuntimePreference.swift"
+  "$SRCROOT/macgit/Models/GitRuntimeStatus.swift"
+)
+cli_binaries=()
+for cli_arch in $ARCHS; do
+  cli_binary="$cli_work/commit-$cli_arch"
+  xcrun --sdk macosx swiftc -parse-as-library -swift-version 5 \
+    -O -sdk "$SDKROOT" -target "$cli_arch-apple-macosx$MACOSX_DEPLOYMENT_TARGET" \
+    -module-cache-path "$cli_work/ModuleCache" "${cli_sources[@]}" -o "$cli_binary"
+  cli_binaries+=("$cli_binary")
+done
+xcrun lipo -create "${cli_binaries[@]}" -output "$cli_output"
+if [[ "${CODE_SIGNING_ALLOWED:-NO}" == "YES" && -n "${EXPANDED_CODE_SIGN_IDENTITY:-}" ]]; then
+  cli_sign_options=(--force --sign "$EXPANDED_CODE_SIGN_IDENTITY" --options runtime)
+  if [[ "$EXPANDED_CODE_SIGN_IDENTITY" != "-" ]]; then
+    cli_sign_options+=(--timestamp)
+  fi
+  /usr/bin/codesign "${cli_sign_options[@]}" "$cli_output"
+fi

--- a/scripts/test-command-line.sh
+++ b/scripts/test-command-line.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -euo pipefail
+cli_root="$(cd "$(dirname "$0")/.." && pwd)"
+cli_test_dir="$(mktemp -d)"
+trap 'rm -rf "$cli_test_dir"' EXIT
+cli_sources=()
+while IFS= read -r cli_source; do
+  case "$cli_source" in
+    *.swift)
+      [[ "$cli_source" == *CommitCommand.swift ]] && continue
+      cli_sources+=("$cli_root/${cli_source#*/}")
+      ;;
+  esac
+done < "$cli_root/command-line/inputs.xcfilelist"
+xcrun swiftc -parse-as-library -swift-version 5 \
+  "${cli_sources[@]}" "$cli_root/macgit/Services/CommandLineInstaller.swift" \
+  "$cli_root/macgit/Services/CommandLineShellConfiguration.swift" \
+  "$cli_root/macgit/Services/CommandLineReminderPolicy.swift" \
+  "$cli_root/macgit/ViewModels/CommandLineSetupModel.swift" \
+  "$cli_root/command-line/Tests.swift" -o "$cli_test_dir/tests"
+"$cli_test_dir/tests"


### PR DESCRIPTION
Add a `commit` command that opens Git repositories in Commit+ directly from Terminal.

Users can run:

```sh
commit
commit .
commit /path/to/repository
```

The command resolves the Git working-tree root, including subdirectories and linked worktrees, then opens or focuses the corresponding Commit+ window.
What changed
- Added a native commit helper bundled inside the app.
- Added macgit://open-repository routing for repository handoff.
- Added Git repository validation before opening Commit+.
- Invalid folders and non-Git directories return an error in Terminal with a nonzero exit code.
- Added CLI installation to ~/.local/bin/commit.
- Added automatic PATH setup for zsh, bash, and fish.
- Preserved existing shell configuration and created backups before modifying it.
- Added startup setup tip with:
  - Install CLI & Configure PATH
  - Close
  - Don’t remind
- Added Command Line settings with the same installation flow.
- Added syntax-highlighted command blocks with copy buttons.
- Added focus behavior for repositories that are already open.
- Updated README and implementation documentation.
Validation
- bash scripts/test-command-line.sh
  - 45 parser, URL, repository resolver, worktree, shell configuration, reminder policy, and installation checks passed.
- xcodebuild -project macgit.xcodeproj -scheme macgit -destination 'platform=macOS' build
  - Build succeeded.
- git diff --check
  - Passed.
- Verified the packaged helper signature, --help, invalid-path handling, non-Git error handling, and invalid argument handling.
Manual UI validation is still recommended for the startup modal, copy button feedback, and Command Line settings interaction.